### PR TITLE
add loading spinner for verbatimtextouput delay

### DIFF
--- a/ui.R
+++ b/ui.R
@@ -1,5 +1,6 @@
 library(shiny)
 library(shinythemes)
+library(shinycssloaders)
 library(plotly)
 
 ui <- fluidPage(
@@ -27,7 +28,14 @@ ui <- fluidPage(
       uiOutput("progress_bar"),
       wellPanel(
         div(
-          align = "left", verbatimTextOutput("prompt"),
+          align = "left",
+          withSpinner(
+            verbatimTextOutput("prompt"),
+            type = 2,
+            color = "#0079cb",
+            color.background = "#ffd538",
+            proxy.height = "100px"
+          ),
           textInput(
             inputId = "answer_box",
             label = "SQL!",


### PR DESCRIPTION
Add indication of something loading when query verbatimtextouput is blocked by leaderboard read.  Prolly should decouple the 2, but..................... look at the pretty bandaid

<img width="1069" alt="image" src="https://github.com/AdamSpannbauer/sql-racer/assets/16326083/94aabab2-2c79-477b-bce4-deb6101fb4ac">

@AlexanderHolmes0 , would merging this break anything you're working on or can I merge and you rebase easy enough?  this can wait to be in main code base until after anything you're doing if it causes even a little friction